### PR TITLE
Account for gzipped fasta path

### DIFF
--- a/.github/workflows/test-checkm-rs.yml
+++ b/.github/workflows/test-checkm-rs.yml
@@ -12,13 +12,12 @@ jobs:
         matrix:
             os: ["ubuntu-latest"]
     steps:
-      - uses: actions/checkout@v2
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: actions/checkout@v4
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           activate-environment: test
           environment-file: checkm-rs.yml
           auto-activate-base: false
-          mamba-version: "*"
           channels: conda-forge,defaults
       - run: |
           conda info


### PR DESCRIPTION
assumes all filenames ending in .gz will also have some other ext prior (e.g. .fna.gz)
also removed some identity mapping that clippy complained about